### PR TITLE
Update callbacks.md

### DIFF
--- a/callbacks.md
+++ b/callbacks.md
@@ -92,5 +92,44 @@ In addition, it can be helpful to also use the focus and blur callbacks that CKE
     	//  other code ... maybe show a failure notification
     }
     ```
+
+3. Cancel edits in the onCancel event without having to refresh the page.
+
+    While CKEditor does have an undo manager and periodically takes snapshots of your content so that it can be undone, for a simple onCancel functionality, we can just save the initial contents of the editor as a data attribute in the on focus event.  The following should give you a general idea of how to implement this.
+
+    ```
+    function saveEditorState(editor) {
+        var containerId = editor.container.getId();
+        document.getElementById(containerId).dataset.savedHTML = editor.getData();  // Save current editor state in data attribute
+    }
+
+    function restoreEditorState(editor) {
+        var containerId = editor.container.getId(),
+            dataset = document.getElementById(containerId).dataset;
+        if (savedHTML in dataset) {                          // Make sure state was actually saved
+            editor.setData(dataset.savedHTML);               // Restore state from data attribute
+        }
+    }
+    
+    config.inlinesave.onSuccess = function(editor, data) { 
+        saveEditorState(editor);                            // Saves the current state on successful save.
+        // Show notifications, hide spinner, etc.
+    };
+
+    config.inlinecancel.onCancel = function(editor) { 
+        restoreEditorState(editor);                         // Undo all changes since last time state was saved.
+        // Show notifications, etc.
+    };
+
+    config.on = {
+      focus: function(event) {
+            saveEditorState(event.editor);      // Need to save the initial state.
+      },
+      blur: function(event) {
+            restoreEditorState(event.editor);   // Makes blur work like cancel... Delete this if you don't want that.
+      }
+    };
+    ```
+    
 *Feel free to contribute pull requests for this file to add additional examples of use cases.  
 Your input and contributions are greatly appreciated!*


### PR DESCRIPTION
Added the third example use case in callbacks.md to show how to undo changes via saving the editor's current state as a data attribute and restoring it to clear changes in the onCancel event.
