### PR TITLE
Update plugin.js

### DIFF
--- a/src/inlinesave/plugin.js
+++ b/src/inlinesave/plugin.js
@@ -9,7 +9,6 @@ CKEDITOR.plugins.add( 'inlinesave',
 			{
 				exec : function( editor )
 				{
-                    var sendDataOk = true;
 					var postData = {},
 					    payload = '',
 					    contentType = 'application/x-www-form-urlencoded; charset=UTF-8';
@@ -25,55 +24,59 @@ CKEDITOR.plugins.add( 'inlinesave',
 					}
 
 					if (typeof config.onSave == "function") {
-						sendDataOk = config.onSave(editor); // Allow showing 'loading' spinner
-					}
-
-					if (!sendDataOk) {
-						throw new Error("CKEditor inlinesave: Saving Disable by return of onSave function = false");
-						return;
-					}
-					else {
+						var sendDataOk = config.onSave(editor); // Allow showing 'loading' spinner or aborting
 						
-						// Clone postData object from config and add editabledata and editorID properties
-						CKEDITOR.tools.extend(postData, config.postData || {}, true); // Clone config.postData to prevent changing the config.
-						postData.editabledata = editor.getData();
-						postData.editorID = editor.container.getId();
-
-						// If user opts to use JSON format for sending data to server, use Content-type 'application/json'.
-						if (!!config.useJSON) {
-								payload = JSON.stringify(postData);
-								contentType = 'application/json; charset=UTF-8';
-						}
-						// Otherwise use the default Content-type, 'application/x-www-form-urlencoded'.
-						else {
-								// Convert postData object to multi-part form data query string for post like jQuery does by default.
-								var formData = '';
-								for (var key in postData) { // Must encode data to handle special characters
-										formData += '&' + key + '=' + encodeURIComponent(postData[key]);
-								}
-								payload = formData.slice(1); // Remove initial '&'
+						if (typeof sendDataOk != "undefined" && !sendDataOk) {  // Explicit return false?
+							if (typeof config.onFailure == "function") {
+								config.onFailure(editor, -1, null);  	// -1 means "Save aborted"
+							}
+							else {
+								throw new Error("CKEditor inlinesave: Saving Disable by return of onSave function = false");
+							}
+							return;
 						}
 
-						// Use pure javascript (no dependencies) and send the data in json format...
-						var xhttp = new XMLHttpRequest();
-						xhttp.onreadystatechange = function () {
-								if (xhttp.readyState == 4) {
-										// If success, call onSuccess callback if defined
-										if (typeof config.onSuccess == "function" && xhttp.status == 200) {
-												// Allow server to return data via xhttp.response
-												config.onSuccess(editor, xhttp.response);
-										}
-										// If error, call onFailure callback if defined
-										else if (typeof config.onFailure == "function") {
-												config.onFailure(editor, xhttp.status, xhttp);
-										}
-								}
-						};
-						xhttp.open("POST", config.postUrl, true);
-						// Send as form data encoded to handle special characters.
-						xhttp.setRequestHeader("Content-type", contentType);
-						xhttp.send(payload);
 					}
+
+					// Clone postData object from config and add editabledata and editorID properties
+					CKEDITOR.tools.extend(postData, config.postData || {}, true); // Clone config.postData to prevent changing the config.
+					postData.editabledata = editor.getData();
+					postData.editorID = editor.container.getId();
+
+					// If user opts to use JSON format for sending data to server, use Content-type 'application/json'.
+					if (!!config.useJSON) {
+						payload = JSON.stringify(postData);
+						contentType = 'application/json; charset=UTF-8';
+					}
+					// Otherwise use the default Content-type, 'application/x-www-form-urlencoded'.
+					else {
+						// Convert postData object to multi-part form data query string for post like jQuery does by default.
+						var formData = '';
+						for (var key in postData) { // Must encode data to handle special characters
+								formData += '&' + key + '=' + encodeURIComponent(postData[key]);
+						}
+						payload = formData.slice(1); // Remove initial '&'
+					}
+
+					// Use pure javascript (no dependencies) and send the data in json format...
+					var xhttp = new XMLHttpRequest();
+					xhttp.onreadystatechange = function () {
+						if (xhttp.readyState == 4) {
+							// If success, call onSuccess callback if defined
+							if (typeof config.onSuccess == "function" && xhttp.status == 200) {
+								// Allow server to return data via xhttp.response
+								config.onSuccess(editor, xhttp.response);
+							}
+							// If error, call onFailure callback if defined
+							else if (typeof config.onFailure == "function") {
+								config.onFailure(editor, xhttp.status, xhttp);
+							}
+						}
+					};
+					xhttp.open("POST", config.postUrl, true);
+					// Send as form data encoded to handle special characters.
+					xhttp.setRequestHeader("Content-type", contentType);
+					xhttp.send(payload);
 				}
 			});
 		editor.ui.addButton( 'Inlinesave',


### PR DESCRIPTION
I think an error for onSave should only be thrown if the return value (sendDataOk) is explicitly set to false.  No return value being set (== "undefined) should not cause an error to be thrown.  Since "undefined" and false are both falsey values, must differentiate between them.  However, is throwing an error always the best approach?  How about checking of onFailure is set and calling that with a xhttp.status semaphore value of -1 if the save was aborted?

Also the else is not needed bfore the CKEDITOR.tools.extend line  because the return exits the function if the if is true.
