### PR TITLE
Added notification messages for success/error

### DIFF
--- a/src/inlinesave/lang/de.js
+++ b/src/inlinesave/lang/de.js
@@ -1,0 +1,5 @@
+
+CKEDITOR.plugins.setLang( 'inlinesave', 'de', {
+	successMessage: "Erfolgreich gespeichert",
+	errorMessage: "Fehler beim Speichern",
+} );

--- a/src/inlinesave/lang/en.js
+++ b/src/inlinesave/lang/en.js
@@ -1,0 +1,5 @@
+
+CKEDITOR.plugins.setLang( 'inlinesave', 'en', {
+	successMessage: "Successfully saved",
+	errorMessage: "Error while saving"
+} );

--- a/src/inlinesave/plugin.js
+++ b/src/inlinesave/plugin.js
@@ -1,5 +1,6 @@
 CKEDITOR.plugins.add( 'inlinesave',
 {
+	lang: ["en", "de"],
 	init: function( editor )
 	{
 		var config = editor.config.inlinesave,
@@ -64,13 +65,25 @@ CKEDITOR.plugins.add( 'inlinesave',
 					xhttp.onreadystatechange = function () {
 						if (xhttp.readyState == 4) {
 							// If success, call onSuccess callback if defined
-							if (typeof config.onSuccess == "function" && xhttp.status == 200) {
-								// Allow server to return data via xhttp.response
-								config.onSuccess(editor, xhttp.response);
+							if (xhttp.status == 200) {
+								if(typeof config.onSuccess == "function") {
+									// Allow server to return data via xhttp.response
+									config.onSuccess(editor, xhttp.response);
+								}
+								// show notification
+								if(config.showSuccessMessage === true){
+									editor.showNotification(editor.lang.inlinesave.successMessage, "success");
+								}
 							}
 							// If error, call onFailure callback if defined
-							else if (typeof config.onFailure == "function") {
-								config.onFailure(editor, xhttp.status, xhttp);
+							else {
+								if (typeof config.onFailure == "function") {
+									config.onFailure(editor, xhttp.status, xhttp);
+								}
+								
+								if(config.showErrorMessage === true){
+									editor.showNotification(editor.lang.inlinesave.errorMessage, "warning");
+								}
 							}
 						}
 					};


### PR DESCRIPTION
I added two config options: showErrorMessage and showSuccessMessage. If they are true, a notification using editor.showNotification (see http://docs.ckeditor.com/#!/guide/dev_notifications) will be displayed.

- Maybe the === true comparisons in plugin.js on line 74 and 84 are unneccessary...
- I did not update the files in dist/.
- Maybe it would be a good idea to show the error reason in the notification... 