### PR TITLE
Add notification plugin as dependency

### DIFF
--- a/src/inlinesave/plugin.js
+++ b/src/inlinesave/plugin.js
@@ -1,5 +1,6 @@
 CKEDITOR.plugins.add( 'inlinesave',
 {
+	requires: 'notification',
 	init: function( editor )
 	{
 		var config = editor.config.inlinesave,


### PR DESCRIPTION
Prior PR added notification plug-in as dependency but that is not indicated in the plug-in JavaScript.  This fixes that.

Frankly, I would prefer a graceful degradation approach (check if notification plug-in is loaded or use alert() as a fall-back) so using the notification plug-in is not required, but adding notification as a dependency is a simpler fix.