### PR TITLE
Added confirm message if user wants to leave a page with unsaved changes

### DIFF
--- a/src/inlinesave/lang/de.js
+++ b/src/inlinesave/lang/de.js
@@ -1,0 +1,6 @@
+
+CKEDITOR.plugins.setLang( 'inlinesave', 'de', {
+	successMessage: "Erfolgreich gespeichert",
+        errorMessage: "Fehler beim Speichern",
+        leaveConfirmMessage: "Sie haben noch ungespeicherte Änderungen! Möchten Sie ohne Speichern fortfahren?",
+} );

--- a/src/inlinesave/lang/en.js
+++ b/src/inlinesave/lang/en.js
@@ -2,5 +2,5 @@
 CKEDITOR.plugins.setLang( 'inlinesave', 'en', {
 	successMessage: "Successfully saved",
         errorMessage: "Error while saving",
-        leaveConfirmMessage: "You have unsaved changed! Do you want to continue without saving?",
+        leaveConfirmMessage: "You have unsaved changes! Do you want to continue without saving?",
 } );

--- a/src/inlinesave/lang/en.js
+++ b/src/inlinesave/lang/en.js
@@ -1,0 +1,6 @@
+
+CKEDITOR.plugins.setLang( 'inlinesave', 'en', {
+	successMessage: "Successfully saved",
+        errorMessage: "Error while saving",
+        leaveConfirmMessage: "You have unsaved changed! Do you want to continue without saving?",
+} );

--- a/src/inlinesave/plugin.js
+++ b/src/inlinesave/plugin.js
@@ -12,6 +12,27 @@ CKEDITOR.plugins.add( 'inlinesave',
 
 		iconName = !!config.useColorIcon ? 'inlinesave-color.svg' : 'inlinesave.svg';
 
+		// remind to save unsaved changes
+		if(config.confirmUnsavedChanged)
+		{
+			window.onbeforeunload = function(eventArgs)
+			{
+				if(editor.checkDirty())
+				{
+					var message = editor.lang.inlinesave.leaveConfirmMessage;
+					eventArgs = eventArgs || window.event;
+					// For IE and Firefox
+					if (eventArgs) 
+					{
+						eventArgs.returnValue = message;
+					}
+
+					// For Safari
+					return message;
+				}
+			}
+		}
+
 		editor.addCommand( 'inlinesave',
 			{
 				exec : function( editor )
@@ -66,6 +87,8 @@ CKEDITOR.plugins.add( 'inlinesave',
 						if (xhttp.readyState == 4) {
 							// If success, call onSuccess callback if defined
 							if (xhttp.status == 200) {
+								editor.resetDirty( );
+								
 								if(typeof config.onSuccess == "function") {
 									// Allow server to return data via xhttp.response
 									config.onSuccess(editor, xhttp.response);

--- a/src/inlinesave/plugin.js
+++ b/src/inlinesave/plugin.js
@@ -13,7 +13,7 @@ CKEDITOR.plugins.add( 'inlinesave',
 		iconName = !!config.useColorIcon ? 'inlinesave-color.svg' : 'inlinesave.svg';
 
 		// remind to save unsaved changes
-		if(config.confirmUnsavedChanged)
+		if(config.confirmUnsavedChanges)
 		{
 			window.onbeforeunload = function(eventArgs)
 			{


### PR DESCRIPTION
If the configuration option confirmUnsavedChanges is set to true, a user leaving a page with a dirty editor (means unsaved changes) will be reminded to save changes.